### PR TITLE
fix: Expose webapp acess

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
 # jsreport .net docker-compose example
 
-Simply open in VS and run docker with F5.   
+Simply open in VS and run docker with F5.
 
-The example shows how you can run jsreport outside your app what is generally a better practice. It shows how you can use the [jsreport.AspNetCore](https://jsreport.net/learn/dotnet-aspnetcore) and Razor views to render reports through "external" jsreport docker container.    
+The example shows how you can run jsreport outside your app what is generally a better practice. It shows how you can use the [jsreport.AspNetCore](https://jsreport.net/learn/dotnet-aspnetcore) and Razor views to render reports through "external" jsreport docker container.
 
 Additionally, it shows how you can define reports inside jsreport studio. Mount the data volume so your templates stay in the version control. And how to render such stored reports from your app.
 
 
+### how to run
+
+Open in Visual Code for example, and type in the terminal:
+
+    docker-compose up --build
+
+if you have problems have a file (`cleaner-ALL-container.ps1`) that automates the process of cleaning all containers, use with care.
+
+**You can access:**
+
+Webapp (contains examples)
+http://localhost:32768/
+
+And check the JsReport server:
+http://localhost:5488/

--- a/WebApp/Dockerfile
+++ b/WebApp/Dockerfile
@@ -1,6 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
+RUN apt-get update && apt-get install -y procps
 WORKDIR /app
 EXPOSE 80
 

--- a/cleaner-ALL-container.ps1
+++ b/cleaner-ALL-container.ps1
@@ -1,0 +1,4 @@
+docker container stop $(docker container ls -aq)
+docker container rm $(docker container ls -aq)
+docker image rm $(docker image ls -aq)
+docker system prune

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,33 @@
 version: '3.4'
-
 services:
   webapp:
-    image: ${DOCKER_REGISTRY-}webapp
+    image: '${DOCKER_REGISTRY-}webapp'
     build:
       context: .
       dockerfile: WebApp/Dockerfile
-  jsreport:
-    image: jsreport/jsreport:2.9.0
-    container_name: jsreport
     ports:
-      - "5488:5488" 
+      - '46900:80'
+    networks:
+      internal_network:
+        ipv4_address: 172.18.0.10
+      external_network: 
+    environment:
+      - 'ReportingServiceUrl=http://jsreport:5488'
+  jsreport:
+    image: 'jsreport/jsreport:2.9.0'
+    container_name: jsreport
     volumes:
-      - ./jsreport:/jsreport
+      - './jsreport:/jsreport'
+    ports:
+      - '5488:5488'
+    networks:
+      internal_network:
+        ipv4_address: 172.18.0.11
+networks:
+  internal_network:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.18.0.0/24
+  external_network:


### PR DESCRIPTION
the example was not functional to the point of pulling and running, it needed some simple modifications to make it even easier for more people to use.

NOTE: There was no problem with the code, just to make it easier to use, exposing access to the Webapp and jsreport services.